### PR TITLE
Remove compilation warnings

### DIFF
--- a/src/main/java/eu/mihosoft/freerouting/autoroute/BatchOptRoute.java
+++ b/src/main/java/eu/mihosoft/freerouting/autoroute/BatchOptRoute.java
@@ -118,7 +118,7 @@ public class BatchOptRoute
     {
         java.util.ResourceBundle resources =
                 java.util.ResourceBundle.getBundle("eu.mihosoft.freerouting.interactive.InteractiveState", this.thread.hdlg.get_locale());
-        String start_message = resources.getString("batch_optimizer") + " " + resources.getString("stop_message") + "        " + resources.getString("pass") + " " + (new Integer(p_pass_no)).toString() + ": ";
+        String start_message = resources.getString("batch_optimizer") + " " + resources.getString("stop_message") + "        " + resources.getString("pass") + " " + (Integer.valueOf(p_pass_no)).toString() + ": ";
         this.thread.hdlg.screen_messages.set_status_message(start_message);
         this.thread.hdlg.remove_ratsnest();
         int incomplete_count_before = this.thread.hdlg.get_ratsnest().incomplete_count();

--- a/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
@@ -1310,7 +1310,7 @@ public class BasicBoard implements java.io.Serializable
             {
                 for (int i = 0; i < curr_item.net_count(); ++i)
                 {
-                    p_changed_nets.add(new Integer(curr_item.get_net_no(i)));
+                    p_changed_nets.add(Integer.valueOf(curr_item.get_net_no(i)));
                 }
             }
         }
@@ -1327,7 +1327,7 @@ public class BasicBoard implements java.io.Serializable
             {
                 for (int i = 0; i < curr_item.net_count(); ++i)
                 {
-                    p_changed_nets.add(new Integer(curr_item.get_net_no(i)));
+                    p_changed_nets.add(Integer.valueOf(curr_item.get_net_no(i)));
                 }
             }
         }

--- a/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/BasicBoard.java
@@ -708,7 +708,7 @@ public class BasicBoard implements java.io.Serializable
     /**
      * Combines the connected traces of this net, which have only 1 contact
      * at the connection point.
-     * if p_net_no < 0 traces of all nets are combined.
+     * if p_net_no {@literal <} 0 traces of all nets are combined.
      */
     public boolean combine_traces(int p_net_no)
     {
@@ -848,7 +848,7 @@ public class BasicBoard implements java.io.Serializable
 
     /**
      * Returns all SearchTreeObjects on layer p_layer, which overlap with p_shape.
-     * If p_layer < 0, the layer is ignored
+     * If p_layer {@literal <} 0, the layer is ignored
      */
     public Set<SearchTreeObject> overlapping_objects(ConvexShape p_shape, int p_layer)
     {
@@ -862,7 +862,7 @@ public class BasicBoard implements java.io.Serializable
      * which describes the required clearance restrictions to other items.
      * The function may also return items, which are nearly overlapping,
      * but do not overlap with exact calculation.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public Set<Item> overlapping_items_with_clearance(ConvexShape p_shape, int p_layer, int[] p_ignore_net_nos,
                                                       int p_clearance_class)
@@ -873,7 +873,7 @@ public class BasicBoard implements java.io.Serializable
 
     /**
      * Returns all items on layer p_layer, which overlap with p_area.
-     * If p_layer < 0, the layer is ignored
+     * If p_layer {@literal <} 0, the layer is ignored
      */
     public Set<Item> overlapping_items(Area p_area, int p_layer)
     {
@@ -1085,7 +1085,7 @@ public class BasicBoard implements java.io.Serializable
 
     /**
      * Returns the list of items on the eu.mihosoft.freerouting.board, whose shape on layer p_layer contains the point at p_location.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      * If p_item_selection_filter != null, only items of types selected by the filter are picked.
      */
     public Set<Item> pick_items(Point p_location, int p_layer, ItemSelectionFilter p_filter)

--- a/src/main/java/eu/mihosoft/freerouting/board/Components.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/Components.java
@@ -68,7 +68,7 @@ public class Components implements java.io.Serializable
      */
     public Component add(Point p_location, double p_rotation, boolean p_on_front, Package p_package)
     {
-        String component_name = "Component#" + (new Integer(component_arr.size() + 1)).toString();
+        String component_name = "Component#" + (Integer.valueOf(component_arr.size() + 1)).toString();
         return add(component_name, p_location, p_rotation, p_on_front, p_package, p_package, false);
     }
     

--- a/src/main/java/eu/mihosoft/freerouting/board/Connectable.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/Connectable.java
@@ -68,7 +68,7 @@ public interface Connectable
     /**
      * Returns all connectable items of the net with number p_net_no, which can be reached recursively
      * from this item via normal contacts.
-     * if (p_net_no <= 0, the net number is ignored.
+     * if (p_net_no {@literal <}= 0, the net number is ignored.
      */
     Set<Item> get_connected_set(int p_net_no);
     

--- a/src/main/java/eu/mihosoft/freerouting/board/DrillItem.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/DrillItem.java
@@ -476,19 +476,19 @@ public abstract class DrillItem extends Item implements Connectable, java.io.Ser
     
     /**
      * Contains the precalculated mininal width of the shapes of this DrillItem on all layers.
-     * If < 0, the value is not yet calculated
+     * If {@literal <} 0, the value is not yet calculated
      */
     private double precalculated_min_width = -1;
     
     /**
      * Contains the precalculated first layer, where this DrillItem contains a pad shape.
-     * If < 0, the value is not yet calculated
+     * If {@literal <} 0, the value is not yet calculated
      */
     private int precalculated_first_layer = -1;
     
     /**
      * Contains the precalculated last layer, where this DrillItem contains a pad shape.
-     * If < 0, the value is not yet calculated
+     * If {@literal <} 0, the value is not yet calculated
      */
     private int precalculated_last_layer = -1;
     

--- a/src/main/java/eu/mihosoft/freerouting/board/Item.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/Item.java
@@ -212,7 +212,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
 
     /**
      * Creates a copy of this item with id number p_id_no.
-     * If p_id_no <= 0, the id_no of the new item is generated internally
+     * If p_id_no {@literal <}= 0, the id_no of the new item is generated internally
      */
     public abstract Item copy(int p_id_no);
 
@@ -570,7 +570,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
     /**
      * Returns the set of all Connectable items of the net with number p_net_no which can be reached recursively
      * via normal contacts from this item.
-     * If p_net_no <= 0, the net number is ignored.
+     * If p_net_no {@literal <}= 0, the net number is ignored.
      */
     public Set<Item> get_connected_set(int p_net_no)
     {
@@ -580,7 +580,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
     /**
      * Returns the set of all Connectable items of the net with number p_net_no which can be reached recursively
      * via normal contacts from this item.
-     * If p_net_no <= 0, the net number is ignored.
+     * If p_net_no {@literal <}= 0, the net number is ignored.
      * If p_stop_at_plane, the recursive algorithm stops, when a conduction area is reached,
      * which does not belong to a component.
      */
@@ -673,7 +673,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
     /**
      * Returns the set of all Connectable items belonging to the net with number p_net_no,
      * which are not in the connected set of this item.
-     * If p_net_no <= 0, the net numbers contained in this items are used  instead of p_net_no.
+     * If p_net_no {@literal <}= 0, the net numbers contained in this items are used  instead of p_net_no.
      */
     public Set<Item> get_unconnected_set(int p_net_no)
     {
@@ -876,7 +876,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
 
     /**
      * Returns for this item the layer of the shape with index p_index.
-     * If p_id_no <= 0, it w2ill be generated internally.
+     * If p_id_no {@literal <}= 0, it w2ill be generated internally.
      */
     public abstract int shape_layer(int p_index);
 
@@ -1004,7 +1004,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
     }
 
     /**
-     * gets the p_no-th net number of this item for 0 <= p_no < this.net_count().
+     * gets the p_no-th net number of this item for 0 {@literal <}= p_no {@literal <} this.net_count().
      */
     public int get_net_no(int p_no)
     {
@@ -1103,7 +1103,7 @@ public abstract class Item implements Drawable, SearchTreeObject, ObjectInfoPane
 
     /**
      * Makes this item connectable and assigns it to the input net.
-     * If p_net_no < 0, the net items net number will be removed and the item will no longer be connectable.
+     * If p_net_no {@literal <} 0, the net items net number will be removed and the item will no longer be connectable.
      */
     public void assign_net_no(int p_net_no)
     {

--- a/src/main/java/eu/mihosoft/freerouting/board/PullTightAlgo.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/PullTightAlgo.java
@@ -577,7 +577,7 @@ public abstract class PullTightAlgo
 
     abstract Polyline smoothen_end_corner_at_trace(PolylineTrace p_trace);
     protected final RoutingBoard board;
-    /** If only_net_no > 0, only nets with this net numbers are optimized. */
+    /** If only_net_no {@literal >} 0, only nets with this net numbers are optimized. */
     protected final int[] only_net_no_arr;
     protected int curr_layer;
     protected int curr_half_width;

--- a/src/main/java/eu/mihosoft/freerouting/board/RoutingBoard.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/RoutingBoard.java
@@ -207,11 +207,11 @@ public class RoutingBoard extends BasicBoard implements java.io.Serializable
 
     /**
      * Optimizes the route in the internally marked area.
-     * If p_net_no > 0, only traces with net number p_net_no are optimized.
+     * If p_net_no {@literal >} 0, only traces with net number p_net_no are optimized.
      * If p_clip_shape != null the optimizing is restricted to p_clip_shape.
      * p_trace_cost_arr is used for optimizing vias and may be null.
      * If p_stoppable_thread != null, the agorithm can be requested to be stopped.
-     * If p_time_limit > 0; the algorithm will be stopped after p_time_limit Milliseconds.
+     * If p_time_limit {@literal >} 0; the algorithm will be stopped after p_time_limit Milliseconds.
      */
     public void opt_changed_area(int[] p_only_net_no_arr, IntOctagon p_clip_shape, int p_accuracy, ExpansionCostFactor[] p_trace_cost_arr,
             Stoppable p_stoppable_thread, int p_time_limit)
@@ -222,11 +222,11 @@ public class RoutingBoard extends BasicBoard implements java.io.Serializable
 
     /**
      * Optimizes the route in the internally marked area.
-     * If p_net_no > 0, only traces with net number p_net_no are optimized.
+     * If p_net_no {@literal >} 0, only traces with net number p_net_no are optimized.
      * If p_clip_shape != null the optimizing is restricted to p_clip_shape.
      * p_trace_cost_arr is used for optimizing vias and may be null.
      * If p_stoppable_thread != null, the agorithm can be requested to be stopped.
-     * If p_time_limit > 0; the algorithm will be stopped after p_time_limit Milliseconds.
+     * If p_time_limit {@literal >} 0; the algorithm will be stopped after p_time_limit Milliseconds.
      * If p_keep_point != null, traces on layer p_keep_point_layer containing p_keep_point
      *  will also contain this point after optimizing.
      */
@@ -491,7 +491,7 @@ public class RoutingBoard extends BasicBoard implements java.io.Serializable
      * If  p_from_item != null, items, which are connected to p_from_item, are
      * ignored.
      * Returns null, if no item is found,
-     * If p_layer < 0, the layer is ignored
+     * If p_layer {@literal <} 0, the layer is ignored
      */
     public Item pick_nearest_routing_item(Point p_location, int p_layer, Item p_from_item)
     {
@@ -982,7 +982,7 @@ public class RoutingBoard extends BasicBoard implements java.io.Serializable
 
     /**
      *  Autoroutes from the input pin until the first via, in case the pin and its connected set
-     *  has only 1 layer. Ripup is allowed if p_ripup_costs is >= 0.
+     *  has only 1 layer. Ripup is allowed if p_ripup_costs is {@literal >}= 0.
      *  Returns an enum of type AutorouteEngine.AutorouteResult
      */
     public AutorouteEngine.AutorouteResult fanout(Pin p_pin, eu.mihosoft.freerouting.interactive.Settings p_settings, int p_ripup_costs,
@@ -1124,7 +1124,7 @@ public class RoutingBoard extends BasicBoard implements java.io.Serializable
 
     /**
      * Removes all trace tails of the input net.
-     * If p_net_no <= 0, the tails of all nets are removed.
+     * If p_net_no {@literal <}= 0, the tails of all nets are removed.
      *  Returns true, if something was removed.
      */
     public boolean remove_trace_tails(int p_net_no, Item.StopConnectionOption p_stop_connection_option)

--- a/src/main/java/eu/mihosoft/freerouting/board/ShapeSearchTree.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/ShapeSearchTree.java
@@ -347,7 +347,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
     /**
      * Puts all items in the tree overlapping with p_shape
      * on layer p_layer into p_obstacles.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public void overlapping_objects(ConvexShape p_shape, int p_layer, int[] p_ignore_net_nos,
             Set<SearchTreeObject> p_obstacles)
@@ -367,7 +367,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
 
     /**
      * Returns all SearchTreeObjects on layer p_layer, which overlap with p_shape.
-     * If p_layer < 0, the layer is ignored
+     * If p_layer {@literal <} 0, the layer is ignored
      */
     public Set<SearchTreeObject> overlapping_objects(ConvexShape p_shape, int p_layer)
     {
@@ -379,7 +379,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
     /**
      * Puts all tree entries overlapping with p_shape
      * on layer p_layer into the list p_obstacles.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public void overlapping_tree_entries(ConvexShape p_shape, int p_layer, Collection<TreeEntry> p_tree_entries)
     {
@@ -389,7 +389,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
     /**
      * Puts all tree entries overlapping with p_shape
      * on layer p_layer into the list p_obstacles.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      * tree_entries with object containing a net number of p_ignore_net_nos are ignored.
      */
     public void overlapping_tree_entries(ConvexShape p_shape, int p_layer, int[] p_ignore_net_nos,
@@ -553,7 +553,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
     /**
      * Puts all items in the tree overlapping with p_shape
      * on layer p_layer into p_obstacles, if p_obstacles != null.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public void overlapping_objects_with_clearance(ConvexShape p_shape, int p_layer, int[] p_ignore_net_nos,
             int p_cl_type, Set<SearchTreeObject> p_obstacles)
@@ -585,7 +585,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
      * which describes the required clearance restrictions to other items.
      * The function may also return items, which are nearly overlapping,
      * but do not overlap with exact calculation.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public Set<Item> overlapping_items_with_clearance(ConvexShape p_shape, int p_layer, int[] p_ignore_net_nos,
             int p_clearance_class)
@@ -610,7 +610,7 @@ public class ShapeSearchTree extends eu.mihosoft.freerouting.datastructures.MinA
      * inclusive clearance.
      * p_clearance_class is the index in the clearance matrix,
      * which describes the required clearance restrictions to other items.
-     * If p_layer < 0, the layer is ignored.
+     * If p_layer {@literal <} 0, the layer is ignored.
      */
     public Collection<TreeEntry> overlapping_tree_entries_with_clearance(ConvexShape p_shape, int p_layer,
             int[] p_ignore_net_nos, int p_clearance_class)

--- a/src/main/java/eu/mihosoft/freerouting/board/TestLevel.java
+++ b/src/main/java/eu/mihosoft/freerouting/board/TestLevel.java
@@ -25,7 +25,7 @@
 package eu.mihosoft.freerouting.board;
 
 /**
- * If > RELEASE, some features may be used, which are still in experimental state.
+ * If {@literal >} RELEASE, some features may be used, which are still in experimental state.
  * Also warnings for debugging may be printed depending on the test_level.
  *
  * @author alfons

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Circle.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Circle.java
@@ -95,7 +95,7 @@ public class Circle extends Shape
         for (int i = 0; i < coor.length; ++i)
         {
             p_file.write(" ");
-            p_file.write(new Double(coor[i]).toString());
+            p_file.write(Double.valueOf(coor[i]).toString());
         }
         p_file.write(")");
     }

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Component.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Component.java
@@ -104,7 +104,7 @@ public class Component extends ScopeKeyword
             for (int i = 0; i < coor.length; ++i)
             {
                 p_par.file.write(" ");
-                p_par.file.write((new Double(coor[i])).toString());
+                p_par.file.write((Double.valueOf(coor[i])).toString());
             }
             if (p_component.placed_on_front())
             {

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Component.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Component.java
@@ -115,7 +115,7 @@ public class Component extends ScopeKeyword
                 p_par.file.write(" back ");
             }
             int rotation = (int) Math.round(p_component.get_rotation_in_degree());
-            p_par.file.write((new Integer(rotation).toString()));
+            p_par.file.write((Integer.valueOf(rotation).toString()));
         }
         if (p_component.position_fixed)
         {

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Package.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Package.java
@@ -194,7 +194,7 @@ public class Package
             if (rotation != 0)
             {
                 p_par.file.write("(rotate ");
-                p_par.file.write((new Integer(rotation)).toString());
+                p_par.file.write((Integer.valueOf(rotation)).toString());
                 p_par.file.write(")");
             }
             p_par.file.write(")");

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Package.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Package.java
@@ -188,7 +188,7 @@ public class Package
             for(int j = 0; j < rel_coor.length; ++j)
             {
                 p_par.file.write(" ");
-                p_par.file.write((new Double(rel_coor[j])).toString());
+                p_par.file.write((Double.valueOf(rel_coor[j])).toString());
             }
             int rotation = (int) Math.round(curr_pin.rotation_in_degree);
             if (rotation != 0)

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Polygon.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Polygon.java
@@ -112,9 +112,9 @@ public class Polygon extends Shape
         for (int i = 0; i < corner_count; ++i)
         {
             p_file.new_line();
-            p_file.write(new Double(coor[2 * i]).toString());
+            p_file.write(Double.valueOf(coor[2 * i]).toString());
             p_file.write(" ");
-            p_file.write(new Double(coor[2 * i + 1]).toString());
+            p_file.write(Double.valueOf(coor[2 * i + 1]).toString());
         }
         p_file.end_scope();
     }

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Polygon.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Polygon.java
@@ -107,7 +107,7 @@ public class Polygon extends Shape
         p_file.write("polygon ");
         p_identifier_type.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Integer(0)).toString());
+        p_file.write((Integer.valueOf(0)).toString());
         int corner_count = coor.length/ 2;
         for (int i = 0; i < corner_count; ++i)
         {
@@ -125,7 +125,7 @@ public class Polygon extends Shape
         p_file.write("polygon ");
         p_identifier_type.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Integer(0)).toString());
+        p_file.write((Integer.valueOf(0)).toString());
         int corner_count = coor.length/ 2;
         for (int i = 0; i < corner_count; ++i)
         {

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/PolygonPath.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/PolygonPath.java
@@ -54,14 +54,14 @@ public class PolygonPath extends Path
         p_file.write("path ");
         p_identifier_type.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Double(this.width)).toString());
+        p_file.write((Double.valueOf(this.width)).toString());
         int corner_count = coordinate_arr.length/ 2;
         for (int i = 0; i < corner_count; ++i)
         {
             p_file.new_line();
-            p_file.write(new Double(coordinate_arr[2 * i]).toString());
+            p_file.write(Double.valueOf(coordinate_arr[2 * i]).toString());
             p_file.write(" ");
-            p_file.write(new Double(coordinate_arr[2 * i + 1]).toString());
+            p_file.write(Double.valueOf(coordinate_arr[2 * i + 1]).toString());
         }
         p_file.end_scope();
     }
@@ -72,7 +72,7 @@ public class PolygonPath extends Path
         p_file.write("path ");
         p_identifier_type.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Double(this.width)).toString());
+        p_file.write((Double.valueOf(this.width)).toString());
         int corner_count = coordinate_arr.length/ 2;
         for (int i = 0; i < corner_count; ++i)
         {

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/PolylinePath.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/PolylinePath.java
@@ -50,14 +50,14 @@ public class PolylinePath extends Path
         p_file.write("polyline_path ");
         p_identifier.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Double(this.width)).toString());
+        p_file.write((Double.valueOf(this.width)).toString());
         int line_count = coordinate_arr.length/ 4;
         for (int i = 0; i < line_count; ++i)
         {
             p_file.new_line();
             for (int j = 0; j < 4; ++j)
             {
-                p_file.write(new Double(coordinate_arr[4 * i + j]).toString());
+                p_file.write(Double.valueOf(coordinate_arr[4 * i + j]).toString());
                 p_file.write(" ");
             }
         }
@@ -70,7 +70,7 @@ public class PolylinePath extends Path
         p_file.write("polyline_path ");
         p_identifier.write(this.layer.name, p_file);
         p_file.write(" ");
-        p_file.write((new Double(this.width)).toString());
+        p_file.write((Double.valueOf(this.width)).toString());
         int line_count = coordinate_arr.length/ 4;
         for (int i = 0; i < line_count; ++i)
         {

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Rectangle.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Rectangle.java
@@ -109,7 +109,7 @@ public class Rectangle extends Shape
         for (int i = 0; i < coor.length; ++i)
         {
             p_file.write(" ");
-            p_file.write(new Double(coor[i]).toString());
+            p_file.write(Double.valueOf(coor[i]).toString());
         }
         p_file.write(")");
     }

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Resolution.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Resolution.java
@@ -84,7 +84,7 @@ public class Resolution extends ScopeKeyword
         p_file.write("(resolution ");
         p_file.write(p_board_communication.unit.toString());
         p_file.write(" ");
-        p_file.write((new Integer(p_board_communication.resolution)).toString());
+        p_file.write((Integer.valueOf(p_board_communication.resolution)).toString());
         p_file.write(")");
     }
     

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Rule.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Rule.java
@@ -182,7 +182,7 @@ public abstract class Rule
         double trace_width = 2 * p_par.coordinate_transform.board_to_dsn(default_trace_half_width);
         p_par.file.new_line();
         p_par.file.write("(width ");
-        p_par.file.write((new Double(trace_width)).toString());
+        p_par.file.write((Double.valueOf(trace_width)).toString());
         p_par.file.write(")");
         p_par.file.end_scope();
         for (int i = 1; i < p_par.board.layer_structure.arr.length; ++i)
@@ -211,7 +211,7 @@ public abstract class Rule
         double trace_width = 2 * p_par.coordinate_transform.board_to_dsn(curr_trace_half_width);
         p_par.file.new_line();
         p_par.file.write("(width ");
-        p_par.file.write((new Double(trace_width)).toString());
+        p_par.file.write((Double.valueOf(trace_width)).toString());
         p_par.file.write(") ");
         p_par.file.end_scope();
         p_par.file.end_scope();
@@ -228,7 +228,7 @@ public abstract class Rule
         double trace_width = 2 * p_par.coordinate_transform.board_to_dsn(p_par.board.rules.get_default_net_class().get_trace_half_width(0));
         p_par.file.new_line();
         p_par.file.write("(width ");
-        p_par.file.write((new Double(trace_width)).toString());
+        p_par.file.write((Double.valueOf(trace_width)).toString());
         p_par.file.write(")");
         // write the default clearance rule
         int default_cl_no = eu.mihosoft.freerouting.rules.BoardRules.default_clearance_class();
@@ -236,7 +236,7 @@ public abstract class Rule
         double default_clearance = p_par.coordinate_transform.board_to_dsn(default_board_clearance);
         p_par.file.new_line();
         p_par.file.write("(clear ");
-        p_par.file.write((new Double(default_clearance)).toString());
+        p_par.file.write((Double.valueOf(default_clearance)).toString());
         p_par.file.write(")");
         // write the Smd_to_turn_gap
         Double smd_to_turn_dist = p_par.coordinate_transform.board_to_dsn(p_par.board.rules.get_pin_edge_to_turn_dist());
@@ -269,7 +269,7 @@ public abstract class Rule
             double curr_clearance = p_par.coordinate_transform.board_to_dsn(curr_board_clearance);
             p_par.file.new_line();
             p_par.file.write("(clear ");
-            p_par.file.write((new Double(curr_clearance)).toString());
+            p_par.file.write((Double.valueOf(curr_clearance)).toString());
             p_par.file.write(" (type ");
             p_par.identifier_type.write(cl_matrix.get_name(p_cl_class), p_par.file);
             p_par.file.write("_");

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SessionFile.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SessionFile.java
@@ -185,7 +185,7 @@ public class SessionFile
             p_file.write(" back ");
         }
         int rotation = (int) Math.round(p_component.get_rotation_in_degree());
-        p_file.write((new Integer(rotation).toString()));
+        p_file.write((Integer.valueOf(rotation).toString()));
         if (p_component.position_fixed)
         {
             p_file.new_line();
@@ -470,14 +470,14 @@ public class SessionFile
         p_file.write("path ");
         p_identifier_type.write(p_layer_name, p_file);
         p_file.write(" ");
-        p_file.write((new Integer(p_width)).toString());
+        p_file.write((Integer.valueOf(p_width)).toString());
         int corner_count = p_coors.length/ 2;
         for (int i = 0; i < corner_count; ++i)
         {
             p_file.new_line();
-            p_file.write(new Integer(p_coors[2 * i]).toString());
+            p_file.write(Integer.valueOf(p_coors[2 * i]).toString());
             p_file.write(" ");
-            p_file.write(new Integer(p_coors[2 * i + 1]).toString());
+            p_file.write(Integer.valueOf(p_coors[2 * i + 1]).toString());
         }
         p_file.end_scope();
     }

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SpecctraFileScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SpecctraFileScanner.java
@@ -1424,7 +1424,7 @@ class SpecctraFileScanner implements Scanner {
           }
         case 235: break;
         case 5: 
-          { return new Integer(yytext());
+          { return Integer.valueOf(yytext());
           }
         case 236: break;
         case 25: 

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SpecctraFileScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/SpecctraFileScanner.java
@@ -1299,7 +1299,7 @@ class SpecctraFileScanner implements Scanner {
           }
         case 204: break;
         case 15: 
-          { return new Double(yytext());
+          { return Double.valueOf(yytext());
           }
         case 205: break;
         case 42: 

--- a/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Wiring.java
+++ b/src/main/java/eu/mihosoft/freerouting/designforms/specctra/Wiring.java
@@ -178,7 +178,7 @@ class Wiring extends ScopeKeyword
         for (int i = 0; i < via_coor.length; ++i)
         {
             p_par.file.write(" ");
-            p_par.file.write((new Double(via_coor[i])).toString());
+            p_par.file.write((Double.valueOf(via_coor[i])).toString());
         }
         if (via_net != null)
         {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/ConvexShape.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/ConvexShape.java
@@ -34,7 +34,7 @@ public interface ConvexShape extends Shape
     
     /**
      * Calculates the offset shape by p_distance.
-     * If p_distance > 0, the shape will be enlarged, else the result
+     * If p_distance {@literal >} 0, the shape will be enlarged, else the result
      * shape will be smaller.
      */
     ConvexShape offset(double p_distance);

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Direction.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Direction.java
@@ -179,8 +179,8 @@ public abstract class  Direction implements Comparable<Direction>, java.io.Seria
     /**
      * The function returns
      *   Signum.POSITIVE, if the scalar product of of a vector representing
-     *                    this direction and a vector representing p_other is > 0,
-     *   Signum.NEGATIVE, if the scalar product is < 0,
+     *                    this direction and a vector representing p_other is {@literal >} 0,
+     *   Signum.NEGATIVE, if the scalar product is {@literal <} 0,
      *   and Signum.ZERO, if the scalar product is equal 0.
      */
     public Signum projection(Direction p_other)

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Ellipse.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Ellipse.java
@@ -63,7 +63,7 @@ public class Ellipse implements java.io.Serializable
     
     public final FloatPoint center;
     
-    /** Rotation of the ellipse in radian normed to 0 <= rotation < pi */
+    /** Rotation of the ellipse in radian normed to 0 {@literal <}= rotation {@literal <} pi */
     public final double rotation;
     public final double bigger_radius;
     public final double  smaller_radius;

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/FloatLine.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/FloatLine.java
@@ -90,7 +90,7 @@ public class FloatLine
     
     /**
      * translates the line perpendicular at about p_dist.
-     * If p_dist > 0, the line will be translated to the left, else to the right
+     * If p_dist {@literal >} 0, the line will be translated to the left, else to the right
      */
     public FloatLine translate(double p_dist)
     {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/IntBox.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/IntBox.java
@@ -198,7 +198,7 @@ public class IntBox extends RegularTileShape implements java.io.Serializable
     /**
      * Calculates the sorted p_max_result_points nearest points on the  border of this box.
      * p_point is assumed to be located in the interiour of this nox.
-     * The funtion is only  imoplemented for p_max_result_points <= 2;
+     * The funtion is only  imoplemented for p_max_result_points {@literal <}= 2;
      */
     public IntPoint[] nearest_border_projections(IntPoint p_point, int p_max_result_points)
     {
@@ -530,7 +530,7 @@ public class IntBox extends RegularTileShape implements java.io.Serializable
     
     /**
      * Returns the box offseted by p_dist.
-     * If p_dist > 0, the offset is to the outside,
+     * If p_dist {@literal >} 0, the offset is to the outside,
      * else to the inside.
      */
     public IntBox offset(double p_dist)
@@ -547,7 +547,7 @@ public class IntBox extends RegularTileShape implements java.io.Serializable
     
     /**
      * Returns the box, where the horizontal boundary is offseted by p_dist.
-     * If p_dist > 0, the offset is to the outside,
+     * If p_dist {@literal >} 0, the offset is to the outside,
      * else to the inside.
      */
     public IntBox horizontal_offset(double p_dist)
@@ -564,7 +564,7 @@ public class IntBox extends RegularTileShape implements java.io.Serializable
     
     /**
      * Returns the box, where the vertical boundary is offseted by p_dist.
-     * If p_dist > 0, the offset is to the outside,
+     * If p_dist {@literal >} 0, the offset is to the outside,
      * else to the inside.
      */
     public IntBox vertical_offset(double p_dist)

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/IntVector.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/IntVector.java
@@ -210,8 +210,8 @@ public class IntVector extends Vector implements java.io.Serializable
     
     /**
      * The function returns
-     *   Signum.POSITIVE, if the scalar product of this vector and p_other > 0,
-     *   Signum.NEGATIVE, if the scalar product Vector is < 0,
+     *   Signum.POSITIVE, if the scalar product of this vector and p_other {@literal >} 0,
+     *   Signum.NEGATIVE, if the scalar product Vector is {@literal <} 0,
      *   and Signum.ZERO, if the scalar product is equal 0.
      */
     public Signum projection(Vector p_other)

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Line.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Line.java
@@ -447,7 +447,7 @@ public class Line implements Comparable<Line>, java.io.Serializable
     
     /**
      * translates the line perpendicular at about p_dist.
-     * If p_dist > 0, the line will be translated to the left, else to the right
+     * If p_dist {@literal >} 0, the line will be translated to the left, else to the right
      */
     public Line translate(double p_dist)
     {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Polygon.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Polygon.java
@@ -135,8 +135,8 @@ public class Polygon implements java.io.Serializable
     }
     /**
      * Returns the winding number of this polygon, treated as closed.
-     * It will be > 0, if the corners are in countercock sense,
-     * and < 0, if the corners are in clockwise sense.
+     * It will be {@literal >} 0, if the corners are in countercock sense,
+     * and {@literal <} 0, if the corners are in clockwise sense.
      */
     public int winding_number_after_closing()
     {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Polyline.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Polyline.java
@@ -45,7 +45,7 @@ public class Polyline implements java.io.Serializable
      * creates a polyline of length p_polygon.corner_count + 1 from p_polygon,
      * so that the i-th corner of p_polygon will be the intersection of
      * the i-th and the i+1-th lines of the new created p_polyline
-     * for 0 <= i < p_point_arr.length. p_polygon must have at least 2 corners
+     * for 0 {@literal <}= i {@literal <} p_point_arr.length. p_polygon must have at least 2 corners
      */
     public Polyline(Polygon p_polygon)
     {
@@ -597,7 +597,7 @@ public class Polyline implements java.io.Serializable
     /**
      * Calculates for the p_no-th line segment a shape around this line
      * where the right and left edge lines have the distance p_half_width
-     * from the center line. 0 <= p_no <=  arr.length - 3
+     * from the center line. 0 {@literal <}= p_no {@literal <}=  arr.length - 3
      */
     public TileShape offset_shape(int p_half_width, int p_no)
     {
@@ -613,7 +613,7 @@ public class Polyline implements java.io.Serializable
     /**
      * Calculates for the p_no-th line segment a box shape around this line
      * where the border lines have the distance p_half_width
-     * from the center line. 0 <= p_no <=  arr.length - 3
+     * from the center line. 0 {@literal <}= p_no {@literal <}=  arr.length - 3
      */
     public IntBox offset_box(int p_half_width, int p_no)
     {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/RationalVector.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/RationalVector.java
@@ -147,8 +147,8 @@ public class RationalVector extends Vector implements java.io.Serializable
     
     /**
      * The function returns
-     *   Signum.POSITIVE, if the scalar product of this vector and p_other > 0,
-     *   Signum.NEGATIVE, if the scalar product is < 0,
+     *   Signum.POSITIVE, if the scalar product of this vector and p_other {@literal >} 0,
+     *   Signum.NEGATIVE, if the scalar product is {@literal <} 0,
      *   and Signum.ZERO, if the scalar product is equal 0.
      */
     public Signum projection(Vector p_other)

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Simplex.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Simplex.java
@@ -91,7 +91,7 @@ public class Simplex extends TileShape implements java.io.Serializable
     
     /**
      * Returns true,  if the determinant of the direction of index
-     * p_no -1 and the direction of index p_no is > 0
+     * p_no -1 and the direction of index p_no is {@literal >} 0
      */
     public boolean corner_is_bounded(int p_no)
     {
@@ -684,7 +684,7 @@ public class Simplex extends TileShape implements java.io.Serializable
     
     /**
      * Returns the simplex offseted by p_with.
-     * If p_width > 0, the offset is to the outer, else to the inner.
+     * If p_width {@literal >} 0, the offset is to the outer, else to the inner.
      */
     public Simplex offset(double p_width)
     {

--- a/src/main/java/eu/mihosoft/freerouting/geometry/planar/Vector.java
+++ b/src/main/java/eu/mihosoft/freerouting/geometry/planar/Vector.java
@@ -81,8 +81,8 @@ public abstract class Vector implements java.io.Serializable
     
     /**
      * The function returns
-     *   Signum.POSITIVE, if the scalar product of this vector and p_other > 0,
-     *   Signum.NEGATIVE, if the scalar product Vector is < 0,
+     *   Signum.POSITIVE, if the scalar product of this vector and p_other {@literal >} 0,
+     *   Signum.NEGATIVE, if the scalar product Vector is {@literal <} 0,
      *   and Signum.ZERO, if the scalar product is equal 0.
      */
     public abstract Signum projection(Vector p_other);

--- a/src/main/java/eu/mihosoft/freerouting/gui/BoardFrame.java
+++ b/src/main/java/eu/mihosoft/freerouting/gui/BoardFrame.java
@@ -87,7 +87,7 @@ public class BoardFrame extends javax.swing.JFrame
      * files are allowed, so that the frame can be used in an applet.
      * Currently Option.EXTENDED_TOOL_BAR is used only if a new eu.mihosoft.freerouting.board is
      * created by the application from scratch.
-     * If p_test_level > RELEASE_VERSION, functionality not yet ready for release is included.
+     * If p_test_level {@literal >} RELEASE_VERSION, functionality not yet ready for release is included.
      * Also the warning output depends on p_test_level.
      */
     public BoardFrame(DesignFile p_design, Option p_option, TestLevel p_test_level,

--- a/src/main/java/eu/mihosoft/freerouting/gui/GUIDefaultsScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/gui/GUIDefaultsScanner.java
@@ -1579,7 +1579,7 @@ class GUIDefaultsScanner {
           }
         case 146: break;
         case 7: 
-          { return new Double(yytext());
+          { return Double.valueOf(yytext());
           }
         case 147: break;
         case 69: 

--- a/src/main/java/eu/mihosoft/freerouting/gui/GUIDefaultsScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/gui/GUIDefaultsScanner.java
@@ -1656,7 +1656,7 @@ class GUIDefaultsScanner {
           }
         case 165: break;
         case 4: 
-          { return new Integer(yytext());
+          { return Integer.valueOf(yytext());
           }
         case 166: break;
         case 13: 

--- a/src/main/java/eu/mihosoft/freerouting/gui/WindowSnapshot.java
+++ b/src/main/java/eu/mihosoft/freerouting/gui/WindowSnapshot.java
@@ -154,7 +154,7 @@ public class WindowSnapshot extends BoardSavableSubWindow
             this.snapshot_count = saved_attributes.snapshot_count;
             this.list_model = saved_attributes.list_model;
             this.list.setModel(this.list_model);
-            String next_default_name = "snapshot " + (new Integer(snapshot_count + 1)).toString();
+            String next_default_name = "snapshot " + (Integer.valueOf(snapshot_count + 1)).toString();
             this.name_field.setText(next_default_name);
             this.setLocation(saved_attributes.location);
             this.setVisible(saved_attributes.is_visible);
@@ -251,7 +251,7 @@ public class WindowSnapshot extends BoardSavableSubWindow
             {
                 ++snapshot_count;
                 list_model.addElement(new_snapshot);
-                String next_default_name = resources.getString("snapshot") + " " + (new Integer(snapshot_count + 1)).toString();
+                String next_default_name = resources.getString("snapshot") + " " + (Integer.valueOf(snapshot_count + 1)).toString();
                 name_field.setText(next_default_name);
             }
         }

--- a/src/main/java/eu/mihosoft/freerouting/interactive/BoardHandling.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/BoardHandling.java
@@ -434,7 +434,7 @@ public class BoardHandling extends BoardHandlingImpl
         if (clearance_violations == null)
         {
             clearance_violations = new ClearanceViolations(this.board.get_items());
-            Integer violation_count = new Integer((clearance_violations.list.size() + 1) / 2);
+            Integer violation_count = Integer.valueOf((clearance_violations.list.size() + 1) / 2);
             String curr_message = violation_count.toString() + " " + resources.getString("clearance_violations_found");
             screen_messages.set_status_message(curr_message);
         }

--- a/src/main/java/eu/mihosoft/freerouting/interactive/BoardHandling.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/BoardHandling.java
@@ -376,7 +376,7 @@ public class BoardHandling extends BoardHandlingImpl
 
     /**
      * Sets the manual trace half width used in eu.mihosoft.freerouting.interactive routing.
-     * If p_layer_no < 0, the manual trace half width is changed on all layers.
+     * If p_layer_no {@literal <} 0, the manual trace half width is changed on all layers.
      */
     public void set_manual_trace_half_width(int p_layer_no, int p_value)
     {

--- a/src/main/java/eu/mihosoft/freerouting/interactive/CopyItemState.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/CopyItemState.java
@@ -181,7 +181,7 @@ public class CopyItemState extends InteractiveState
             {
                 //This item belongs to a component
                 int new_cmp_no;
-                Integer curr_key = new Integer(curr_cmp_no);
+                Integer curr_key = Integer.valueOf(curr_cmp_no);
                 if (cmp_no_pairs.containsKey(curr_key))
                 {
                     // the new component for this pin is already created
@@ -225,7 +225,7 @@ public class CopyItemState extends InteractiveState
                             old_component.placed_on_front(), new_package);
                     copied_components.add(new_component);
                     new_cmp_no = new_component.no;
-                    cmp_no_pairs.put(new Integer(curr_cmp_no), new Integer(new_cmp_no));
+                    cmp_no_pairs.put(Integer.valueOf(curr_cmp_no), Integer.valueOf(new_cmp_no));
                 }
                 curr_item.assign_component_no(new_cmp_no);
             }

--- a/src/main/java/eu/mihosoft/freerouting/interactive/DragItemState.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/DragItemState.java
@@ -170,7 +170,7 @@ public class DragItemState extends DragState
                     Item curr_moved_item = it.next();
                     for (int i = 0; i < curr_moved_item.net_count(); ++i)
                     {
-                        changed_nets.add(new Integer(curr_moved_item.get_net_no(i)));
+                        changed_nets.add(Integer.valueOf(curr_moved_item.get_net_no(i)));
                     }
                 }
                 for (Integer curr_net_no : changed_nets)

--- a/src/main/java/eu/mihosoft/freerouting/interactive/Logfile.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/Logfile.java
@@ -243,9 +243,9 @@ public class Logfile
             }
             try
             {
-                this.file_writer.write((new Double(p_corner.x)).toString());
+                this.file_writer.write((Double.valueOf(p_corner.x)).toString());
                 this.file_writer.write(" ");
-                this.file_writer.write((new Double(p_corner.y)).toString());
+                this.file_writer.write((Double.valueOf(p_corner.y)).toString());
                 this.file_writer.write("\n");
             }
             catch (IOException e2)

--- a/src/main/java/eu/mihosoft/freerouting/interactive/Logfile.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/Logfile.java
@@ -203,7 +203,7 @@ public class Logfile
         {
             try
             {
-                this.file_writer.write((new Integer(p_int)).toString());
+                this.file_writer.write((Integer.valueOf(p_int)).toString());
                 this.file_writer.write("\n");
             }
             catch (IOException e2)

--- a/src/main/java/eu/mihosoft/freerouting/interactive/LogfileScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/LogfileScanner.java
@@ -518,7 +518,7 @@ class LogfileScanner {
           }
         case 8: break;
         case 5: 
-          { return new Double(yytext());
+          { return Double.valueOf(yytext());
           }
         case 9: break;
         case 1: 

--- a/src/main/java/eu/mihosoft/freerouting/interactive/LogfileScanner.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/LogfileScanner.java
@@ -510,7 +510,7 @@ class LogfileScanner {
           }
         case 6: break;
         case 4: 
-          { return new Integer(yytext());
+          { return Integer.valueOf(yytext());
           }
         case 7: break;
         case 2: 

--- a/src/main/java/eu/mihosoft/freerouting/interactive/RatsNest.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/RatsNest.java
@@ -144,8 +144,8 @@ public class RatsNest
     
     /**
      *  Returns the length of the violation of the length restriction of the net with number p_net_no,
-     *  > 0, if the cumulative trace length is to big,
-     *  < 0, if the trace length is to smalll,
+     *  {@literal >} 0, if the cumulative trace length is to big,
+     *  {@literal <} 0, if the trace length is to small,
      *  0, if the thace length is ok or the net has no length restrictions
      */
     public double get_length_violation(int p_net_no)

--- a/src/main/java/eu/mihosoft/freerouting/interactive/ScreenMessages.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/ScreenMessages.java
@@ -98,7 +98,7 @@ public class ScreenMessages
     public void set_batch_fanout_info(int p_pass_no, int p_components_to_go)
     {
         Integer components_to_go = p_components_to_go;
-        Integer pass_no = new  Integer(p_pass_no);
+        Integer pass_no = Integer.valueOf(p_pass_no);
         add_field.setText(resources.getString("fanout_pass") + " " +  pass_no.toString() + ": ");
         layer_field.setText(resources.getString("still") + " " 
                 + components_to_go.toString() + " " + resources.getString("components"));

--- a/src/main/java/eu/mihosoft/freerouting/interactive/SelectedItemState.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/SelectedItemState.java
@@ -304,7 +304,7 @@ public class SelectedItemState extends InteractiveState
         {
             Via curr_via = (Via) it.next();
             Vector rel_coor = curr_via.get_center().difference_by(gravity_point);
-            String pin_name = (new Integer(i + 1)).toString();
+            String pin_name = (Integer.valueOf(i + 1)).toString();
             pin_arr[i] = new Package.Pin(pin_name, curr_via.get_padstack().no, rel_coor, 0);
         }
         Package new_package = board.library.packages.add(pin_arr);
@@ -873,7 +873,7 @@ public class SelectedItemState extends InteractiveState
         if (clearance_violations == null)
         {
             clearance_violations = new ClearanceViolations(this.item_list);
-            Integer violation_count = new Integer(clearance_violations.list.size());
+            Integer violation_count = Integer.valueOf(clearance_violations.list.size());
             String curr_message = violation_count.toString() + " " + resources.getString("clearance_violations_found");
             hdlg.screen_messages.set_status_message(curr_message);
         }

--- a/src/main/java/eu/mihosoft/freerouting/interactive/Settings.java
+++ b/src/main/java/eu/mihosoft/freerouting/interactive/Settings.java
@@ -170,7 +170,7 @@ public class Settings implements java.io.Serializable
     }
     
     /**
-     * The horizontal placement grid when moving components, if > 0.
+     * The horizontal placement grid when moving components, if {@literal >} 0.
      */
     public  int get_horizontal_component_grid()
     {
@@ -178,7 +178,7 @@ public class Settings implements java.io.Serializable
     }
     
     /**
-     * The vertical placement grid when moving components, if > 0.
+     * The vertical placement grid when moving components, if {@literal >} 0.
      */
     public  int get_vertical_component_grid()
     {
@@ -238,7 +238,7 @@ public class Settings implements java.io.Serializable
     }
     
     /**
-     * The horizontal placement grid when moving components, if > 0.
+     * The horizontal placement grid when moving components, if {@literal >} 0.
      */
     public  void set_horizontal_component_grid(int p_value)
     {
@@ -250,7 +250,7 @@ public class Settings implements java.io.Serializable
     }
     
     /**
-     * The vertical placement grid when moving components, if > 0.
+     * The vertical placement grid when moving components, if {@literal >} 0.
      */
     public  void set_vertical_component_grid(int p_value)
     {
@@ -530,12 +530,12 @@ public class Settings implements java.io.Serializable
     boolean via_snap_to_smd_center;
     
     /**
-     * The horizontal placement grid when moving components, if > 0.
+     * The horizontal placement grid when moving components, if {@literal >} 0.
      */
     int horizontal_component_grid;
     
     /**
-     * The vertical placement grid when moving components, if > 0.
+     * The vertical placement grid when moving components, if {@literal >} 0.
      */
     int vertical_component_grid;
     

--- a/src/main/java/eu/mihosoft/freerouting/library/LogicalPart.java
+++ b/src/main/java/eu/mihosoft/freerouting/library/LogicalPart.java
@@ -120,7 +120,7 @@ public class LogicalPart implements eu.mihosoft.freerouting.board.ObjectInfoPane
         
         /**
          * The gate swap  code. Gates with the same gate swap code can be swapped.
-         * Gates with swap code <= 0 are not swappable.
+         * Gates with swap code {@literal <}= 0 are not swappable.
          */
         public final int gate_swap_code;
         
@@ -129,7 +129,7 @@ public class LogicalPart implements eu.mihosoft.freerouting.board.ObjectInfoPane
         
         /**
          * The pin swap code of the gate. Pins with the same pin swap code can be swapped inside a gate.
-         * Pins with swap code <= 0 are not swappable.
+         * Pins with swap code {@literal <}= 0 are not swappable.
          */
         public final int gate_pin_swap_code;
     }

--- a/src/main/java/eu/mihosoft/freerouting/library/Packages.java
+++ b/src/main/java/eu/mihosoft/freerouting/library/Packages.java
@@ -109,7 +109,7 @@ public class Packages implements java.io.Serializable
      */
     public Package add(Package.Pin [] p_pin_arr)
     {
-        String package_name = "Package#" + (new Integer(package_arr.size() + 1)).toString();
+        String package_name = "Package#" + (Integer.valueOf(package_arr.size() + 1)).toString();
         
         return add(package_name, p_pin_arr, null, new Package.Keepout [0], new Package.Keepout [0],
                 new Package.Keepout [0], true);

--- a/src/main/java/eu/mihosoft/freerouting/library/Padstacks.java
+++ b/src/main/java/eu/mihosoft/freerouting/library/Padstacks.java
@@ -108,7 +108,7 @@ public class Padstacks implements java.io.Serializable
      */
     public Padstack add(ConvexShape [] p_shapes)
     {
-        String new_name = "padstack#" + (new Integer(padstack_arr.size() + 1).toString());
+        String new_name = "padstack#" + (Integer.valueOf(padstack_arr.size() + 1).toString());
         return add(new_name, p_shapes, false, false);
     }
     

--- a/src/main/java/eu/mihosoft/freerouting/library/Padstacks.java
+++ b/src/main/java/eu/mihosoft/freerouting/library/Padstacks.java
@@ -69,7 +69,7 @@ public class Padstacks implements java.io.Serializable
     }
     
     /**
-     * Returns the padstack with index p_padstack_no for 1 <= p_padstack_no <= padstack_count
+     * Returns the padstack with index p_padstack_no for 1 {@literal <}= p_padstack_no {@literal <}= padstack_count
      */
     public Padstack get(int p_padstack_no)
     {

--- a/src/main/java/eu/mihosoft/freerouting/rules/BoardRules.java
+++ b/src/main/java/eu/mihosoft/freerouting/rules/BoardRules.java
@@ -58,7 +58,7 @@ public class BoardRules implements java.io.Serializable
     
     /**
      * Returns true, if the trace widths used for routing for the input net are equal on all layers.
-     * If p_net_no < 0, the default trace widths for all nets are checked.
+     * If p_net_no {@literal <} 0, the default trace widths for all nets are checked.
      */
     public boolean trace_widths_are_layer_dependent(int p_net_no)
     {
@@ -397,7 +397,7 @@ public class BoardRules implements java.io.Serializable
     /**
      * Returns the minimum distance between the pin border and the next corner
      * of a connected trace por a pin with connection restrictions.
-     * If the result is <= 0, there are no exit restrictions.
+     * If the result is {@literal <}= 0, there are no exit restrictions.
      */
     public double get_pin_edge_to_turn_dist()
     {
@@ -407,7 +407,7 @@ public class BoardRules implements java.io.Serializable
     /**
      * Sets he minimum distance between the pin border and the next corner
      * of a connected trace por a pin with connection restrictions.
-     * if p_value is <= 0, there are no exit restrictions.
+     * if p_value is {@literal <}= 0, there are no exit restrictions.
      */
     public void set_pin_edge_to_turn_dist(double p_value)
     {
@@ -542,7 +542,7 @@ public class BoardRules implements java.io.Serializable
     /**
      * The minimum distance of the pad border to the first turn of a connected trace
      * to a pin with restricted exit directions.
-     * If the value is <= 0, there are no exit restrictions.
+     * If the value is {@literal <}= 0, there are no exit restrictions.
      */
     private double pin_edge_to_turn_dist;
     

--- a/src/main/java/eu/mihosoft/freerouting/rules/ClearanceMatrix.java
+++ b/src/main/java/eu/mihosoft/freerouting/rules/ClearanceMatrix.java
@@ -91,7 +91,7 @@ public class ClearanceMatrix implements java.io.Serializable
     }
     
     /**
-     * Sets the value of all clearance classes with number >= 1
+     * Sets the value of all clearance classes with number {@literal >}= 1
      * to p_value on all layers.
      */
     public void set_default_value(int p_value)
@@ -103,7 +103,7 @@ public class ClearanceMatrix implements java.io.Serializable
     }
     
     /**
-     * Sets the value of all clearance classes with number >= 1
+     * Sets the value of all clearance classes with number {@literal >}= 1
      * to p_value on p_layer.
      */
     public void set_default_value(int p_layer, int p_value)

--- a/src/main/java/eu/mihosoft/freerouting/rules/NetClass.java
+++ b/src/main/java/eu/mihosoft/freerouting/rules/NetClass.java
@@ -193,7 +193,7 @@ public class NetClass implements java.io.Serializable, eu.mihosoft.freerouting.b
 
     /**
      * Returns the minimum trace length of this net class.
-     * If the result is <= 0, there is no minimal trace length restriction.
+     * If the result is {@literal <}= 0, there is no minimal trace length restriction.
      */
     public double get_minimum_trace_length()
     {
@@ -202,7 +202,7 @@ public class NetClass implements java.io.Serializable, eu.mihosoft.freerouting.b
 
     /**
      * Sets the minimum trace length of this net class to p_value.
-     * If p_value is <= 0, there is no minimal trace length restriction.
+     * If p_value is {@literal <}= 0, there is no minimal trace length restriction.
      */
     public void set_minimum_trace_length(double p_value)
     {
@@ -211,7 +211,7 @@ public class NetClass implements java.io.Serializable, eu.mihosoft.freerouting.b
 
     /**
      * Returns the maximum trace length of this net class.
-     * If the result is <= 0, there is no maximal trace length restriction.
+     * If the result is {@literal <}= 0, there is no maximal trace length restriction.
      */
     public double get_maximum_trace_length()
     {
@@ -220,7 +220,7 @@ public class NetClass implements java.io.Serializable, eu.mihosoft.freerouting.b
 
     /**
      * Sets the maximum trace length of this net class to p_value.
-     * If p_value is <= 0, there is no maximal trace length restriction.
+     * If p_value is {@literal <}= 0, there is no maximal trace length restriction.
      */
     public void set_maximum_trace_length(double p_value)
     {

--- a/src/main/java/eu/mihosoft/freerouting/rules/NetClasses.java
+++ b/src/main/java/eu/mihosoft/freerouting/rules/NetClasses.java
@@ -126,7 +126,7 @@ public class NetClasses implements java.io.Serializable
     
     /**
      * Looks, if the list contains a net class with trace half width[i] all equal to p_trace_half_width_arr[i]
-     * for 0 <= i < layer_count, trace clearance class equal to p_trace_clearance_class
+     * for 0 {@literal <}= i {@literal <} layer_count, trace clearance class equal to p_trace_clearance_class
      * and via rule equal to p_via_rule. Returns null, if no such net class was found.
      */
     public NetClass find(int[] p_trace_half_width_arr, int p_trace_clearance_class,  ViaRule p_via_rule)

--- a/src/main/java/eu/mihosoft/freerouting/rules/Nets.java
+++ b/src/main/java/eu/mihosoft/freerouting/rules/Nets.java
@@ -102,7 +102,7 @@ public class Nets implements java.io.Serializable
     public Net new_net(java.util.Locale p_locale)
     {
         java.util.ResourceBundle resources = java.util.ResourceBundle.getBundle("eu.mihosoft.freerouting.rules.Default", p_locale);
-        String net_name = resources.getString("net#") + (new Integer(net_arr.size() + 1)).toString();
+        String net_name = resources.getString("net#") + (Integer.valueOf(net_arr.size() + 1)).toString();
         return add(net_name, 1, false);
     }
 


### PR DESCRIPTION
I reduced the number of warnings from  200+ to 59.

I did the following (repetitive) things:
- Replaced deprecated Interger constuctors with Integer.valueOf
- Replaced deprecated Double constuctors with Double.valueOf
- Fixed the 100+ javadoc warnings by using {@literal x} where it was needed